### PR TITLE
Changing node_modules folder permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY package*.json ./
 
 RUN npm install
 
+RUN ["chmod", "777", "node_modules"]
+
 COPY . .
 
 EXPOSE 8080


### PR DESCRIPTION
# Pasta node_modules inacessível

## Descrição 
A pasta node_modules no interior do container está bloqueada, com isso não é possivel adicionar ou atualizar os pacotes. Para conseguir utilizar um pacote inserido é necessário dar build no container

[Pasta node_modules inacessível](#93 )

## Porque este Pull Request é necessário?
Para que seja possível atualizar e instalar pacotes no container ser precissar dar build novamente

## Critérios de Aceitação
- [x] Pasta node_modules acessível dentro do container

Resolve #93 
![](https://media.giphy.com/media/KHJw9NRFDMom487qyo/giphy.gif)